### PR TITLE
Update LGPL name in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -23,7 +23,7 @@ guarantee your freedom to share and change free software--to make sure the
 software is free for all its users. This General Public License applies to most of
 the Free Software Foundation's software and to any other program whose
 authors commit to using it. (Some other Free Software Foundation software is
-covered by the GNU Library General Public License instead.) You can apply it to
+covered by the GNU Lesser General Public License instead.) You can apply it to
 your programs, too.
 
 When we speak of free software, we are referring to freedom, not price. Our


### PR DESCRIPTION
This is to better align the GPLv2 wording with https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.